### PR TITLE
update how to setup using go install command with Go 1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Install the latest release from [Homebrew](https://brew.sh/) or [GitHub Releases
 brew install int128/tap/kubectl-external-forward
 
 # Go 1.16+
-go install github.com/int128/kubectl-external-forward/cmd/kubectl-external_forward
+go install github.com/int128/kubectl-external-forward/cmd/kubectl-external_forward@latest
 ```
 
 ### Run


### PR DESCRIPTION
Resolves: #40

## Updates

- Update README.md to correct the way to setup this tool using go install command with Go 1.16+