### PR TITLE
disable istio sidecars for externalforwarder pods to avoid conflicts

### DIFF
--- a/pkg/externalforwarder/pod.go
+++ b/pkg/externalforwarder/pod.go
@@ -23,6 +23,7 @@ func newPod(o Option) (*corev1.Pod, error) {
 			Annotations: map[string]string{
 				// do not prevent scale-in of cluster autoscaler
 				"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+				"sidecar.istio.io/inject": "false",
 			},
 		},
 		Spec: corev1.PodSpec{},


### PR DESCRIPTION
Add "sidecar.istio.io/inject": "false" annotation to externalforwarder spec to resolve Istio sidecar conflict with Envoy